### PR TITLE
use /usr/bin/env for find bash to improve portability

### DIFF
--- a/script/add-action.sh
+++ b/script/add-action.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/script/add-ignore-tags.sh
+++ b/script/add-ignore-tags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: script/build.sh
 

--- a/script/create-pull-request.sh
+++ b/script/create-pull-request.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/script/internal/check-git.sh
+++ b/script/internal/check-git.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Lowest version tested against :)
 expected_major=2

--- a/script/internal/check-node.sh
+++ b/script/internal/check-node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$(which node || exit 0)" ]; then
   echo "Unable to find 'node' in the PATH"

--- a/script/internal/generate-scripts.sh
+++ b/script/internal/generate-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/script/internal/set-trace.sh
+++ b/script/internal/set-trace.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 GITHUB_ACTIONS_DEBUG="$(echo "$GITHUB_ACTIONS_DEBUG" | tr a-z A-Z)"
 if [ "$GITHUB_ACTIONS_DEBUG" = 'TRUE' -o "$GITHUB_ACTIONS_DEBUG" = '1' ]; then

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: script/test.sh ./_layout/action-versions.[tar.gz|zip]
 #        Verify the archive is well-formed with an action.[yaml|yml]

--- a/script/update-action.sh
+++ b/script/update-action.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/script/verify-no-unstaged-changes.sh
+++ b/script/verify-no-unstaged-changes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x


### PR DESCRIPTION
Reason: I encountered some problems when using this tool. The version of my machine `/bin/bash` is low and does not support the syntax of `declare -A`, but I installed a new version of bash through homebrew and added it to the environment variable. But with `#!/bin/bash` means that the interpreter cannot use the new bash that I installed in other locations.
Solution: use /usr/bin/env for find bash to improve portability